### PR TITLE
Address PHP's lack of UINT64.

### DIFF
--- a/src/DdTrace/Encoders/MsgPack.php
+++ b/src/DdTrace/Encoders/MsgPack.php
@@ -19,8 +19,19 @@ final class MsgPack implements Encoder
     }
 
     public function encodeTraces(TracesBuffer $traces)
-    {
-        $this->encodedContent = $this->packer->pack($this->tracesFormatter->__invoke($traces));
+    {  
+        $traces = $this->tracesFormatter->__invoke($traces);
+
+        foreach($traces as &$trace) {
+            foreach($trace as &$span) {
+                $span["trace_id"] = (int) $span["trace_id"];
+                $span["span_id"] = (int) $span["span_id"];
+                $span["parent_id"] = (int) $span["parent_id"];
+            }
+        }
+
+        $this->encodedContent = $this->packer->pack($traces);
+       
     }
 
     public function encodeServices(array $services)

--- a/src/DdTrace/Span.php
+++ b/src/DdTrace/Span.php
@@ -16,8 +16,8 @@ class Span
     const ERROR_STACK_KEY = 'error.stack';
     const ERROR_VALUE = 1;
 
-    private $traceId;
-    private $spanId;
+    private $traceId = '';
+    private $spanId = '';
     private $name = '';
     private $resource;
     private $service;
@@ -26,7 +26,7 @@ class Span
 
     /** @var NanotimeInterval */
     private $duration;
-    private $parentId;
+    private $parentId = '';
     private $error = 0;
     private $isSampled = true;
     private $meta = [];
@@ -45,16 +45,16 @@ class Span
     ) {
 
         $start = Nanotime::now();
-        $spanId = $spanId ?: self::randomId();
+        $spanId = $spanId ?: (string) self::randomId(); //casting as a string to keep ids consistant.
         $traceId = $traceId ?: $spanId;
 
         $this->name = (string) $name;
         $this->service = (string) $service;
         $this->resource = (string) $resource;
         $this->start = $start;
-        $this->spanId = (int) $spanId;
-        $this->traceId = (int) $traceId;
-        $this->parentId = (int) $parentId;
+        $this->spanId = (string) $spanId;   //casting as a string to keep uint64 ids passed in from overflowing PHP_INT_MAX
+        $this->traceId = (string) $traceId; //casting as a string to keep uint64 ids passed in from overflowing PHP_INT_MAX
+        $this->parentId = (string) $parentId; //casting as a string to keep uint64 ids passed in from overflowing PHP_INT_MAX
         $this->tracer = $tracer;
     }
 
@@ -126,6 +126,10 @@ class Span
     public function type()
     {
         return $this->type;
+    }
+
+    public function setType($type) {
+        $this->type = $type;
     }
 
     public function start()

--- a/src/DdTrace/Transports/Http.php
+++ b/src/DdTrace/Transports/Http.php
@@ -68,9 +68,9 @@ class Http implements Transport
         } catch (BadResponseException $e) {
             $response = $e->getResponse();
         } catch (Exception $e) {
-            $response = new Response(self::STATUS_CODE_SERVER_ERROR, $e->getMessage());
+            $response = new Response(self::STATUS_CODE_SERVER_ERROR, [], $e->getMessage());
         } catch (Throwable $e) {
-            $response = new Response(self::STATUS_CODE_SERVER_ERROR, $e->getMessage());
+            $response = new Response(self::STATUS_CODE_SERVER_ERROR, [], $e->getMessage());
         } finally {
             return $response;
         }
@@ -101,7 +101,7 @@ class Http implements Transport
         } catch (BadResponseException $e) {
             $response = $e->getResponse();
         } catch (Exception $e) {
-            $response = new Response(self::STATUS_CODE_SERVER_ERROR, $e->getMessage());
+            $response = new Response(self::STATUS_CODE_SERVER_ERROR, [], $e->getMessage());
         } finally {
             return $response;
         }


### PR DESCRIPTION
# This PR addressed the following issues: 
- Address trace ids and parent span ids that are propagated from external sources and are of type UINT64.
- Add setter method for span type field.
- Fix http response function signature.

## Type setter method
The Type field is required for a trace to be used in data dog. There is no way to set this field with out a helper method. 

## Explanation of UINT64 handling
Since PHP does not support UINT64, all id's have been cast to strings to maintain precision when working with distributed traces. The JSON encoder will strip out `"` so that dd-agent will parse ids as UINT64.

The msgPack encoder was updated to just use the ids cast to int64. This will not change how this encoder worked prior to this pr. As a result any id that is larger that `PHP_INT_MAX` will result in the id being set to `PHP_INT_MAX`. Which is php's default behavior. 