### PR TITLE
allowing setting resource on span

### DIFF
--- a/src/DdTrace/Span.php
+++ b/src/DdTrace/Span.php
@@ -152,6 +152,11 @@ class Span
         $this->metrics[$key] = $value;
     }
 
+    public function setResource($resource)
+    {
+        $this->resource = (string) $resource;
+    }
+
     public function setError($e)
     {
         if (!($e instanceof Exception || $e instanceof Throwable)) {


### PR DESCRIPTION
There are some situations where the resource isn't known at creation time. For example when using PDO prepared statements, you may want to set the span resource to the value of the queryString *after* the call to `prepare()`, but you need to create the span *before* in order for the timing to be started.

This PR allows setting the resource after the span is created.