### PR TITLE
meta must always be a string

### DIFF
--- a/src/DdTrace/Span.php
+++ b/src/DdTrace/Span.php
@@ -95,7 +95,7 @@ class Span
 
     public function setMeta($key, $value)
     {
-        $this->meta[$key] = $value;
+        $this->meta[$key] = (string) $value;
     }
 
     public function name()


### PR DESCRIPTION
Traces fail when meta is not a string. This prevents that from happening.